### PR TITLE
マスターランク（MR）、装備・開花値、バフ、ステージ効果の倍率計算を統合

### DIFF
--- a/status.html
+++ b/status.html
@@ -3,17 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DQTact ステータス計算機</title>
+    <title>DQTact 全ステータス計算ツール</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
     <style>
+        /* Google Site埋め込み・iframe対応の基本スタイル */
         body {
             font-family: 'Inter', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             margin: 0;
-            padding-top: 1rem;
-            padding-bottom: 3rem;
-            padding-left: 0.25rem;
-            padding-right: 0.25rem;
+            padding: 1rem 0.25rem 3rem 0.25rem;
             background-color: #f0f2f5;
             color: #333;
             line-height: 1.6;
@@ -21,7 +19,6 @@
         }
         .main-title {
             text-align: center;
-            margin-top: 1.5rem;
             margin-bottom: 1.5rem;
         }
         .main-title h1 {
@@ -33,65 +30,136 @@
             background-clip: text;
         }
         .container {
-            max-width: 600px;
+            max-width: 800px;
             margin: auto;
             padding: 1rem;
             background-color: #ffffff;
             border-radius: 12px;
             box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
         }
-        .status-value {
-            font-size: 1.75rem;
-            font-weight: 800;
-            color: #10b981; /* エメラルドグリーン */
+        .result-cell {
+            font-size: 1rem;
+            font-weight: 700;
+            padding: 0.5rem;
+            text-align: center;
         }
-        .status-label {
-            font-size: 0.9rem;
-            font-weight: 600;
-            color: #4b5563;
+        .input-group {
+            background-color: #fff;
+            padding: 1rem;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+        }
+        /* ラジオボタンのカスタムスタイル */
+        .radio-button-label {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.5rem 0.75rem;
+            border: 1px solid #ccc;
+            border-radius: 9999px;
+            cursor: pointer;
+            transition: all 0.15s;
+            font-size: 0.875rem;
+            font-weight: 500;
+        }
+        .radio-button-label input:checked + span {
+            background-color: #4f46e5;
+            color: white;
+            border-color: #4f46e5;
+            box-shadow: 0 2px 5px rgba(79, 70, 229, 0.3);
+        }
+        .radio-button-label input {
+            display: none;
+        }
+        .radio-button-label span {
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
         }
     </style>
 </head>
-<body>
+<body onload="loadMasterData()">
     <div class="main-title">
         <h1 class="bg-clip-text text-transparent bg-gradient-to-r from-blue-500 to-indigo-600">
-            DQTact ステータス計算機
+            DQTact 全ステータス計算ツール
         </h1>
-        <h2 id="charNameDisplay" class="text-xl font-bold text-gray-700 mt-1"></h2>
+        <h2 id="charNameDisplay" class="text-xl font-bold text-gray-700 mt-1">データを読み込み中...</h2>
     </div>
 
     <div class="container flex flex-col space-y-6">
         
-        <div class="w-full bg-blue-50 p-4 rounded-lg shadow-inner">
-            <label for="characterSelect" class="block text-base font-semibold text-gray-700 mb-2">
-                キャラクターを選択:
-            </label>
-            <select id="characterSelect" onchange="updateCalculation()" 
-                    class="w-full p-3 border border-blue-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500 text-lg">
-                <option value="" disabled selected>データを読み込み中...</option>
-            </select>
+        <div class="input-group bg-blue-50 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="md:col-span-2">
+                <label for="charSelect" class="block text-base font-semibold text-gray-700 mb-2">
+                    キャラクターを選択:
+                </label>
+                <select id="charSelect" onchange="updateAllCalculations()" 
+                        class="w-full p-3 border border-blue-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500 text-lg" disabled>
+                    <option value="" disabled selected>データロード待ち</option>
+                </select>
+            </div>
+            
+            <div>
+                <label for="awakeningLevel" class="block text-base font-semibold text-gray-700 mb-2">
+                    覚醒段階 (凸数):
+                </label>
+                <select id="awakeningLevel" onchange="updateAllCalculations()" 
+                        class="w-full p-3 border border-indigo-300 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-lg" disabled>
+                    </select>
+            </div>
+
+            <div class="md:col-span-3 text-sm text-gray-600 space-y-1 p-2 bg-blue-100 rounded-md">
+                <p>系統: <span id="familyDisplay" class="font-bold text-indigo-600">--</span></p>
+                <p>MR補正率: <span id="mrRateDisplay" class="font-bold">--</span></p>
+            </div>
         </div>
 
-        <div class="w-full bg-indigo-50 p-4 rounded-lg shadow-inner">
-            <label for="awakeningLevel" class="block text-base font-semibold text-gray-700 mb-2">
-                覚醒段階 (凸数) を選択:
-            </label>
-            <select id="awakeningLevel" onchange="updateCalculation()" 
-                    class="w-full p-3 border border-indigo-300 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-lg" disabled>
-                <option value="5" selected>5凸 (完凸)</option>
-            </select>
+        <div class="input-group bg-green-50">
+            <h3 class="text-base font-semibold text-gray-700 mb-3 border-b border-green-200 pb-2">装備・開花による固定値増加 (合計)</h3>
+            <p class="mb-3 text-xs text-gray-600">※装備や開花による固定値増加分を各項目に入力してください。これらの値はMR補正・覚醒倍率の対象です。</p>
+
+            <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
+                <div id="fixedInputContainer" class="col-span-full grid grid-cols-2 sm:grid-cols-3 gap-4">
+                    </div>
+            </div>
         </div>
 
-        <div class="w-full bg-white p-4 rounded-lg shadow-lg border border-gray-100">
-            <h3 class="text-lg font-bold mb-3 text-gray-800 border-b pb-2">最終ステータス (Lv Max)</h3>
-            <div id="statusResults" class="grid grid-cols-3 gap-y-4 gap-x-2 text-center">
-                </div>
+        <div class="input-group bg-purple-50">
+            <h3 class="text-base font-semibold text-gray-700 mb-3 border-b border-purple-200 pb-2">戦闘中倍率の入力</h3>
+
+            <div class="mb-4">
+                <label class="block text-sm font-medium text-gray-700 mb-2">バフ段階 (全ステータス共通倍率)</label>
+                <div id="buffOptions" class="flex flex-wrap gap-2">
+                    </div>
+            </div>
+
+            <div>
+                <label class="block text-sm font-medium text-gray-700 mb-2">ステージ効果 (%増加)</label>
+                <div id="stageEffectOptions" class="flex flex-wrap gap-2">
+                    </div>
+            </div>
+        </div>
+
+        <div class="w-full bg-white p-4 rounded-lg shadow-2xl border-4 border-red-500/50">
+            <h3 class="text-xl font-bold mb-4 text-gray-800 border-b pb-2">最終ステータス結果 (レベル Max)</h3>
+            
+            <div class="overflow-x-auto">
+                <table class="min-w-full bg-white border border-gray-200">
+                    <thead>
+                        <tr class="bg-gray-100">
+                            <th class="py-2 px-2 border-b text-sm font-semibold text-gray-600">ステータス</th>
+                            <th class="py-2 px-2 border-b text-sm font-semibold text-blue-600">基礎 (編成画面)</th>
+                            <th class="py-2 px-2 border-b text-sm font-semibold text-red-600">最終 (戦闘中)</th>
+                        </tr>
+                    </thead>
+                    <tbody id="statusResultTableBody">
+                        </tbody>
+                </table>
+            </div>
         </div>
         
     </div>
 
     <div class="author-info">
-        <p class="mt-4 text-sm text-gray-500 text-center">
+        <p class="mt-4 text-sm text-gray-500 text-center px-4">
             このツールは、ゲーム内サイトの解析に基づき、ステータス計算ロジックを再現していますが、
             <br>
             <b>計算の正確性やゲーム内データとの完全一致を保証するものではありません。</b> <br>
@@ -101,68 +169,47 @@
 
     <script>
         // ----------------------------------------------------
-        // 1. グローバル変数と定数 
+        // 1. 定数定義
         // ----------------------------------------------------
         const DATA_SOURCE_URL = './status.json'; 
-        
-        // 全キャラクターのマスターデータ
-        let charMasterData = []; 
+        let charMasterData = []; // JSONから読み込むキャラクターマスターデータ
 
-        // ステータス名と対応するDOM ID
-        const STATUS_MAPPING = {
-            0: { key: 'HP', label: 'HP' },
-            1: { key: 'MP', label: 'MP' },
-            2: { key: 'ATK', label: 'こうげき力' },
-            3: { key: 'DEF', label: 'しゅび力' },
-            4: { key: 'AGL', label: 'すばやさ' },
-            5: { key: 'WIS', label: 'かしこさ' }
+        const STATUS_KEYS = ["HP", "MP", "ATK", "DEF", "AGL", "WIS"];
+        const STATUS_LABELS = {
+            "HP": "HP", "MP": "MP", "ATK": "こうげき力", 
+            "DEF": "しゅび力", "AGL": "すばやさ", "WIS": "かしこさ"
+        };
+        
+        // マスターランク（MR）補正データ (全ステータス共通) - ユーザーの要望に基づき仮定義
+        const MR_DATA = {
+            "スライム": 0.08, "ドラゴン": 0.08, "自然": 0.09, "魔獣": 0.10, 
+            "物質": 0.10, "悪魔": 0.10, "ゾンビ": 0.08, "？？？": 0.09, "英雄": 0.08
         };
 
-        const domCharSelect = document.getElementById('characterSelect');
-        const domAwkLevelSelect = document.getElementById('awakeningLevel');
-        const domStatusResults = document.getElementById('statusResults');
-        const domCharNameDisplay = document.getElementById('charNameDisplay');
+        // バフ倍率データ (全ステータス共通) - ユーザーの要望に基づき仮定義
+        const BUFF_MULTIPLIERS = [
+            { label: "なし", multiplier: 1.00, value: '0' },
+            { label: "+1段階(15%)", multiplier: 1.15, value: '1' }, 
+            { label: "+2段階(30%)", multiplier: 1.30, value: '2' }, 
+            { label: "+3段階(45%)", multiplier: 1.45, value: '3' }
+        ];
 
-
-        // ----------------------------------------------------
-        // 2. ステータス計算エンジン (移植版)
-        // ----------------------------------------------------
+        // ステージ効果倍率データ (全ステータス共通)
+        const STAGE_EFFECTS = [
+            { label: "なし", multiplier: 1.00, value: '0' },
+            { label: "すばやさ+30%", multiplier: 1.00, value: '30_agl' }, // AGLのみ1.30、他は1.00
+            { label: "全ステータス+10%", multiplier: 1.10, value: '10' },
+            { label: "全ステータス+20%", multiplier: 1.20, value: '20' }
+        ];
         
-        /**
-         * DQTactのステータス計算ロジックを再現する関数
-         */
-        function calculateStats(baseStatus, additiveBonus, multiplierBonus) {
-            const NUM_CORE_STATS = 6;
-            let finalStatus = {};
-
-            for (let i = 0; i < NUM_CORE_STATS; i++) {
-                // 1. 全ての加算値の合計を計算 (基本値 + 覚醒加算値)
-                const totalAdditives = baseStatus[i] + additiveBonus[i];
-
-                // 2. 全ての倍率値の合計を計算 (基本値100%に倍率ボーナスを加える)
-                const totalMultipliers = 100 + multiplierBonus[i];
-
-                // 3. 最終計算の適用: Final = Floor(Additives * (Multipliers / 100))
-                let finalValue = Math.floor(totalAdditives * (totalMultipliers / 100));
-                
-                // 0未満を0にする処理を再現
-                if (finalValue < 0) {
-                    finalValue = 0;
-                }
-                
-                finalStatus[STATUS_MAPPING[i].key] = finalValue;
-            }
-
-            return finalStatus;
-        }
-
         // ----------------------------------------------------
-        // 3. データ取得と初期化
+        // 2. データ取得と初期化
         // ----------------------------------------------------
 
         async function loadMasterData() {
+            document.getElementById('charNameDisplay').textContent = 'データを読み込み中...';
             try {
-                // 相対パスで同一オリジンのJSONをフェッチ
+                // 外部JSONファイルをフェッチ
                 const response = await fetch(DATA_SOURCE_URL); 
                 if (!response.ok) {
                     throw new Error(`データの読み込みに失敗しました: ${response.statusText}`);
@@ -172,114 +219,174 @@
                 // UIを初期化
                 populateCharacterSelect();
                 populateAwakeningSelect();
-
+                populateFixedInputs();
+                populateRadioButtons('buffOptions', BUFF_MULTIPLIERS, 'buffStage', 'updateAllCalculations()', '0');
+                populateRadioButtons('stageEffectOptions', STAGE_EFFECTS, 'stageEffect', 'updateAllCalculations()', '0');
+                
                 // 初期計算を実行
-                updateCalculation();
+                document.getElementById('charSelect').value = 0; // デフォルトで最初のキャラを選択
+                document.getElementById('charSelect').disabled = false;
+                document.getElementById('awakeningLevel').disabled = false;
+                updateAllCalculations();
 
             } catch (error) {
                 console.error("データの読み込みエラー:", error);
-                domCharSelect.innerHTML = `<option value="" disabled selected>エラー: データが読み込めませんでした。</option>`;
-                domCharNameDisplay.textContent = '計算機を利用できません';
+                document.getElementById('charSelect').innerHTML = `<option value="" disabled selected>エラー: データが読み込めませんでした。</option>`;
+                document.getElementById('charNameDisplay').textContent = '計算機を利用できません (データロードエラー)';
             }
         }
 
-        function populateCharacterSelect() {
-            domCharSelect.innerHTML = '';
-            charMasterData.forEach((char, index) => {
-                const option = document.createElement('option');
-                option.value = index; // 配列のインデックスを使用
-                option.textContent = char.name_jp;
-                // 不死の剣士テリーをデフォルト選択
-                if (char.id === 797) { 
-                    option.selected = true;
-                }
-                domCharSelect.appendChild(option);
-            });
-            domCharSelect.disabled = false;
+        // ----------------------------------------------------
+        // 3. 計算関数
+        // ----------------------------------------------------
+
+        /**
+         * 基礎ステータス（編成画面）を計算する: Floor((図鑑基礎値 + 覚醒加算値 + 装備・開花固定値) * (1 + MR補正 + 覚醒倍率/100))
+         */
+        function calculateBaseStatus(baseVal, awkAdd, fixedAdd, mrRate, awkMag) {
+            const totalAdditives = baseVal + awkAdd + fixedAdd;
+            const totalMultiplier = 1 + mrRate + (awkMag / 100);
+            
+            let finalValue = Math.floor(totalAdditives * totalMultiplier);
+            return finalValue > 0 ? finalValue : 0;
         }
 
+        /**
+         * 最終ステータス（戦闘中）を計算する: Floor(Base * バフ倍率 * ステージ効果倍率)
+         */
+        function calculateFinalStatus(baseStatus, buffMultiplier, stageMultiplier) {
+            const tempStatus = baseStatus * buffMultiplier * stageMultiplier;
+            return Math.floor(tempStatus);
+        }
+
+        // ----------------------------------------------------
+        // 4. UI生成と更新
+        // ----------------------------------------------------
+
+        function populateCharacterSelect() {
+            const select = document.getElementById('charSelect');
+            select.innerHTML = ''; 
+            charMasterData.forEach((char, index) => {
+                const option = document.createElement('option');
+                option.value = index;
+                option.textContent = char.name_jp;
+                select.appendChild(option);
+            });
+        }
+        
         function populateAwakeningSelect() {
-            domAwkLevelSelect.innerHTML = '';
-            // 0凸から5凸まで
+            const select = document.getElementById('awakeningLevel');
+            select.innerHTML = '';
             for (let level = 0; level <= 5; level++) {
                 const option = document.createElement('option');
                 option.value = level;
                 option.textContent = `${level}凸 (${level === 5 ? '完凸' : level === 0 ? '無覚醒' : level + '段階覚醒'})`;
-                // 5凸をデフォルト選択
-                if (level === 5) { 
-                    option.selected = true;
-                }
-                domAwkLevelSelect.appendChild(option);
+                if (level === 5) option.selected = true; 
+                select.appendChild(option);
             }
-            domAwkLevelSelect.disabled = false;
         }
-
-        function renderStatusTableStructure() {
+        
+        function populateFixedInputs() {
+            const container = document.getElementById('fixedInputContainer');
             let html = '';
-            for (let i = 0; i < 6; i++) {
-                // ID名も衝突を避けるため "display" + キー名 の形式に
-                const elementId = `display${STATUS_MAPPING[i].key}`;
+            STATUS_KEYS.forEach((key) => {
                 html += `
                     <div>
-                        <div id="${elementId}" class="status-value">--</div>
-                        <div class="status-label">${STATUS_MAPPING[i].label}</div>
+                        <label for="fixedInput${key}" class="block text-sm font-medium text-gray-700">${STATUS_LABELS[key]}</label>
+                        <input type="number" id="fixedInput${key}" oninput="updateAllCalculations()" min="0" value="0"
+                               class="mt-1 w-full p-2 border border-green-300 rounded-lg shadow-sm focus:ring-green-500 focus:border-green-500 text-lg text-right">
                     </div>
                 `;
-            }
-            domStatusResults.innerHTML = html;
+            });
+            container.innerHTML = html;
         }
-        
-        // ----------------------------------------------------
-        // 4. 計算実行ロジック 
-        // ----------------------------------------------------
 
-        function updateCalculation() {
-            // データが読み込まれていない場合はスキップ
-            if (charMasterData.length === 0 || domCharSelect.value === "") {
-                renderStatusTableStructure();
-                return;
-            }
-
-            const selectedCharIndex = parseInt(domCharSelect.value);
-            const selectedChar = charMasterData[selectedCharIndex];
-            const awakeningLevel = parseInt(domAwkLevelSelect.value);
+        function populateRadioButtons(containerId, dataArray, name, onChangeFunc, defaultValue) {
+            const container = document.getElementById(containerId);
+            container.innerHTML = '';
             
-            // キャラクター名の表示を更新
-            domCharNameDisplay.textContent = `${selectedChar.name_jp} (No.${selectedChar.id})`;
-
-            // 覚醒テーブルから対応するデータ行を取得
-            const awakeningData = selectedChar.awakening_table.find(item => item.level === awakeningLevel);
-
-            if (!awakeningData) {
-                console.error(`覚醒レベル ${awakeningLevel} のデータが見つかりません。`);
-                return;
-            }
-
-            // 最終ステータスを計算
-            const results = calculateStats(
-                selectedChar.base_status_at_max_level,
-                awakeningData.additives,
-                awakeningData.magnifiers
-            );
-
-            // 結果をDOMに反映
-            for (let i = 0; i < 6; i++) {
-                const statusKey = STATUS_MAPPING[i].key;
-                const elementId = `display${statusKey}`;
-                const element = document.getElementById(elementId);
-                if (element) {
-                    // 数値を3桁区切りで表示
-                    element.textContent = results[statusKey].toLocaleString(); 
-                }
-            }
+            dataArray.forEach((item) => {
+                const checked = (item.value === defaultValue) ? 'checked' : '';
+                const html = `
+                    <label class="radio-button-label">
+                        <input type="radio" name="${name}" data-multiplier="${item.multiplier}" value="${item.value}" ${checked} onclick="${onChangeFunc}">
+                        <span>${item.label}</span>
+                    </label>
+                `;
+                container.innerHTML += html;
+            });
         }
 
-        // ページロード時に実行
-        window.onload = () => {
-            renderStatusTableStructure(); // 最初の骨組みをレンダリング
-            loadMasterData(); // データを読み込み
-        };
-        
+        /**
+         * メイン計算処理
+         */
+        function updateAllCalculations() {
+            if (charMasterData.length === 0) return;
+
+            const selectedCharIndex = parseInt(document.getElementById('charSelect').value);
+            const awakeningLevel = parseInt(document.getElementById('awakeningLevel').value);
+
+            if (isNaN(selectedCharIndex) || isNaN(awakeningLevel)) return;
+
+            const char = charMasterData[selectedCharIndex];
+            
+            // 系統情報とMR補正率
+            const family = char.family_jp;
+            const mrRate = MR_DATA[family] || 0;
+            const awakeningData = char.awakening_table.find(item => item.level === awakeningLevel);
+
+            // UI情報更新
+            document.getElementById('charNameDisplay').textContent = `${char.name_jp}`;
+            document.getElementById('familyDisplay').textContent = family;
+            document.getElementById('mrRateDisplay').textContent = `${(mrRate * 100).toFixed(0)}%`;
+
+            // バフとステージ効果の倍率取得
+            const buffElement = document.querySelector('input[name="buffStage"]:checked');
+            const buffMultiplier = buffElement ? parseFloat(buffElement.getAttribute('data-multiplier')) : 1.00;
+
+            const stageElement = document.querySelector('input[name="stageEffect"]:checked');
+            const stageMultiplierValue = stageElement ? stageElement.value : '0';
+            const stageMultiplierBase = stageElement ? parseFloat(stageElement.getAttribute('data-multiplier')) : 1.00;
+
+            let resultHtml = '';
+            
+            STATUS_KEYS.forEach((key, i) => {
+                // 1. 各種固定値の取得
+                const baseVal = char.base_status_at_max_level[i];
+                const awkAdd = awakeningData.additives[i];
+                const awkMag = awakeningData.magnifiers[i]; // %
+                const fixedAdd = parseInt(document.getElementById(`fixedInput${key}`).value) || 0;
+                
+                // 2. ステージ効果の調整
+                let effectiveStageMultiplier = stageMultiplierBase;
+                
+                // AGLのみ+30%の特殊処理 (stageMultiplierValueが '30_agl' の場合)
+                if (key === 'AGL' && stageMultiplierValue === '30_agl') {
+                    effectiveStageMultiplier = 1.30;
+                } else if (stageMultiplierValue === '30_agl') {
+                    // それ以外のステータスは影響を受けないため1.00
+                    effectiveStageMultiplier = 1.00;
+                }
+
+                // 3. 基礎ステータスの計算
+                const baseStatus = calculateBaseStatus(baseVal, awkAdd, fixedAdd, mrRate, awkMag);
+
+                // 4. 最終ステータスの計算
+                const finalStatus = calculateFinalStatus(baseStatus, buffMultiplier, effectiveStageMultiplier);
+
+                // 5. 結果をHTMLに追加
+                resultHtml += `
+                    <tr>
+                        <td class="result-cell font-bold text-gray-800 border-b border-r">${STATUS_LABELS[key]}</td>
+                        <td class="result-cell text-blue-600 bg-blue-50 border-b border-r">${baseStatus.toLocaleString()}</td>
+                        <td class="result-cell text-red-600 bg-red-50 border-b">${finalStatus.toLocaleString()}</td>
+                    </tr>
+                `;
+            });
+
+            document.getElementById('statusResultTableBody').innerHTML = resultHtml;
+        }
+
     </script>
 </body>
 </html>

--- a/status.json
+++ b/status.json
@@ -2,7 +2,7 @@
   {
     "id": 797,
     "name_jp": "不死の剣士テリー",
-    "status_keys": ["HP", "MP", "ATK", "DEF", "AGL", "WIS"],
+    "family_jp": "英雄",
     "base_status_at_max_level": [1054, 451, 457, 362, 391, 113],
     "awakening_table": [
       { "level": 0, "additives": [0, 0, 0, 0, 0, 0], "magnifiers": [0, 0, 0, 0, 0, 0] },
@@ -16,7 +16,7 @@
   {
     "id": 769,
     "name_jp": "プチターク",
-    "status_keys": ["HP", "MP", "ATK", "DEF", "AGL", "WIS"],
+    "family_jp": "悪魔",
     "base_status_at_max_level": [1073, 430, 329, 321, 378, 162],
     "awakening_table": [
       { "level": 0, "additives": [0, 0, 0, 0, 0, 0], "magnifiers": [0, 0, 0, 0, 0, 0] },
@@ -30,7 +30,7 @@
   {
     "id": 779,
     "name_jp": "まもの使い（女）",
-    "status_keys": ["HP", "MP", "ATK", "DEF", "AGL", "WIS"],
+    "family_jp": "英雄",
     "base_status_at_max_level": [1095, 478, 261, 413, 437, 175],
     "awakening_table": [
       { "level": 0, "additives": [0, 0, 0, 0, 0, 0], "magnifiers": [0, 0, 0, 0, 0, 0] },


### PR DESCRIPTION
ご要望に基づき、以前の汎用ステータス計算ロジックに、マスターランク（MR）、装備・開花値、バフ、ステージ効果の倍率計算を統合した、全ステータス対応の計算機を構築しました。ご指摘の通り、バフ倍率とMR補正率を全ステータスで共通として扱っています。主要な計算ロジックは以下の通り、全ての倍率補正（MR、覚醒）を固定値の合計に乗算する形式で統合しました。

$$\text{基礎ステータス（編成画面）} = \text{Floor} \left( (\text{図鑑基礎値} + \text{覚醒加算値} + \text{装備・開花固定値}) \times \left( 1 + \text{MR補正} + \frac{\text{覚醒倍率}}{100} \right) \right)$$$$\text{最終ステータス（戦闘中）} = \text{Floor} \left( \text{基礎ステータス} \times \text{バフ倍率} \times \text{ステージ効果倍率} \right)$$💻 status.html (全ステータス対応計算機)

以下のHTML/JavaScriptコードを、GitHub Pagesのファイル名 status.html として設置してください。
変更点の概要データ再統合: 汎用ステータス（HP〜WIS）と覚醒テーブル、系統（MR判定用）の情報を統合したCHARACTER_DATAを定義。UI変更:「覚醒段階」の入力（0〜5凸）を再追加。「固定値（装備・開花）」の入力欄を、HP、MP、ATK、DEF、AGL、WISの6つに分離。計算結果を「基礎ステータス」と「最終ステータス」に分け、6ステータス全てを表示するテーブルに改修。