### PR TITLE
レイアウト改善と開花ロールバック、アバーんのステータスを1.25割して無凸補正を減算

### DIFF
--- a/status.html
+++ b/status.html
@@ -30,11 +30,14 @@
             background-clip: text;
         }
         .container {
-            /* 左右のパディングを完全に削除 */
-            padding: 1rem 0; 
-            background-color: transparent; 
-            border-radius: 0; 
-            box-shadow: none; 
+            /* センタリングと最大幅を適用 */
+            max-width: 800px;
+            margin: auto; 
+            /* 左右のパディングを戻す */
+            padding: 1rem; 
+            background-color: #ffffff; 
+            border-radius: 12px; 
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08); 
         }
         .result-cell {
             font-size: 0.9rem; 
@@ -61,6 +64,13 @@
             font-size: 1.1rem;
             font-weight: 900;
             color: #dc2626; 
+        }
+        /* 作者情報セクションのセンタリングと余白設定 */
+        .author-info {
+            max-width: 800px;
+            margin: 1rem auto 3rem auto; /* 上下のmarginと中央揃え */
+            padding: 0 1rem; /* 左右にわずかな余白 (1rem) */
+            text-align: left; /* テキストは左揃えを維持 */
         }
     </style>
 </head>
@@ -161,7 +171,7 @@
                 <table class="min-w-full bg-white border border-gray-200">
                     <thead>
                         <tr class="bg-gray-100">
-                            <th class="py-2 px-1 border-b text-xs font-semibold text-gray-600">ステ (バフ率)</th>
+                            <th class="py-2 px-1 border-b text-xs font-semibold text-gray-600">ステ (<span class="text-xs">バフ率</span>)</th>
                             <th class="py-2 px-1 border-b text-xs font-semibold text-blue-600">基礎</th>
                             <th class="py-2 px-1 border-b text-xs font-semibold text-red-600">1up</th>
                             <th class="py-2 px-1 border-b text-xs font-semibold text-red-600">2up</th>

--- a/status.html
+++ b/status.html
@@ -42,10 +42,16 @@
         .result-cell {
             font-size: 0.9rem; 
             font-weight: 700;
-            /* 修正: 垂直パディングを減らし、モバイルでの高さを縮小 */
             padding: 0.25rem 0.25rem; 
             text-align: center;
             white-space: nowrap; 
+            cursor: pointer; /* ホバー/タップで計算式を表示するため */
+        }
+        /* ホバー時の視覚的なフィードバック */
+        .result-cell:hover, .result-cell:focus {
+            background-color: #bae6fd !important; /* light-blue-200 */
+            outline: 2px solid #3b82f6;
+            outline-offset: -2px;
         }
         .input-group {
             background-color: #fff;
@@ -92,7 +98,8 @@
                 </select>
             </div>
             
-            <div class="col-span-full md:col-span-1"> <label for="awakeningLevel" class="block text-base font-semibold text-gray-700 mb-2">
+            <div class="col-span-full md:col-span-1">
+                <label for="awakeningLevel" class="block text-base font-semibold text-gray-700 mb-2">
                     覚醒段階 (凸数):
                 </label>
                 <select id="awakeningLevel" onchange="updateAllCalculations()" 
@@ -126,7 +133,9 @@
         <div class="input-group bg-green-50">
             <h3 class="text-base font-semibold text-gray-700 mb-3 border-b border-green-200 pb-2">装備・開花による固定値増加 (合計)</h3>
             
-            <div class="mb-4 p-2 bg-gray-50 border border-gray-200 rounded-lg"> <label class="block text-sm font-semibold text-gray-700 mb-2"> 才能開花/スキルパネル:
+            <div class="mb-4 p-2 bg-gray-50 border border-gray-200 rounded-lg">
+                <label class="block text-sm font-semibold text-gray-700 mb-2">
+                    才能開花/スキルパネル:
                 </label>
                 <div class="flex space-x-4">
                     <label class="inline-flex items-center">
@@ -143,7 +152,8 @@
                 </div>
             </div>
 
-            <div class="mb-4 flex gap-3 justify-center"> <button onclick="setFixedAgl(FASTEST_AGL_VALUE, true)" class="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-1 text-sm rounded-lg transition duration-150 shadow-md whitespace-nowrap">
+            <div class="mb-4 flex gap-3 justify-center">
+                <button onclick="setFixedAgl(FASTEST_AGL_VALUE, true)" class="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-1 text-sm rounded-lg transition duration-150 shadow-md whitespace-nowrap">
                     ⚡ 最速装備 (+182)
                 </button>
                 <button onclick="resetFixedValues()" class="flex-1 bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-1 text-sm rounded-lg transition duration-150 shadow-md whitespace-nowrap">
@@ -162,7 +172,8 @@
         </div>
 
         <div class="w-full bg-white py-4 rounded-lg shadow-2xl border-4 border-red-500/50">
-            <h3 class="text-lg font-bold mb-4 text-gray-800 border-b pb-2 flex justify-between items-center px-4"> <span>最終ステータス結果 (Lv Max)</span>
+            <h3 class="text-lg font-bold mb-4 text-gray-800 border-b pb-2 flex justify-between items-center px-4">
+                <span>最終ステータス結果 (Lv Max)</span>
                 <span id="summaryDisplay" class="text-xs font-semibold text-gray-600">--</span> 
             </h3>
             
@@ -180,6 +191,13 @@
                     <tbody id="statusResultTableBody">
                         </tbody>
                 </table>
+            </div>
+        </div>
+        
+        <div id="calculationDisplayContainer" class="input-group bg-gray-700 text-white p-3 rounded-lg hidden">
+            <h3 class="text-sm font-semibold mb-2">選択セルの計算式</h3>
+            <div id="calculationDisplay" class="font-mono text-xs bg-gray-800 p-2 rounded overflow-x-auto whitespace-pre-wrap break-words">
+                セルにカーソルを合わせるか、タップしてください。
             </div>
         </div>
 
@@ -213,7 +231,7 @@
             なおこのHTMLコードはGoogleのGeminiによって生成されました。
         </p>
         <div class="version-info mt-3">
-            <p class="text-xs text-gray-500">最終更新日: 2025/12/08 バージョン: 0.1.8 (パネル値修正、UI最適化)</p>
+            <p class="text-xs text-gray-500">最終更新日: 2025/12/08 バージョン: 0.1.9 (計算式表示機能、UI最適化)</p>
         </div>
     </div>
 
@@ -306,6 +324,9 @@
                     }
                 }
                 
+                // 2. 計算式表示のイベントリスナー設定 (一度だけ実行)
+                setupCalculationDisplayListeners();
+
                 updateAllCalculations(); 
 
             } catch (error) {
@@ -459,7 +480,6 @@
                 });
                 aglInput.value = aglValue; // AGLは上書き
             } else {
-                // このロジックは開花ボタン削除に伴い使われませんが、関数定義は維持
                 const currentAgl = parseInt(aglInput.value) || 0;
                 aglInput.value = currentAgl + aglValue;
             }
@@ -505,7 +525,7 @@
         }
 
         /**
-         * メイン計算処理 (特性ボーナスを覚醒テーブルから読み込むように修正)
+         * メイン計算処理
          */
         function updateAllCalculations() {
             if (charMasterData.length === 0) return;
@@ -520,6 +540,11 @@
             
             const awakeningData = char.awakening_table.find(item => item.level === awakeningLevel);
             if (!awakeningData) return;
+            
+            // 2. 計算式表示エリアをクリア
+            document.getElementById('calculationDisplay').innerHTML = 'セルにカーソルを合わせるか、タップしてください。';
+            document.getElementById('calculationDisplayContainer').classList.add('hidden');
+
 
             // 1. 覚醒加算値の表示
             const awkAdditives = awakeningData.additives;
@@ -535,7 +560,7 @@
             }
             document.getElementById('awakeningAdditivesDisplay').innerHTML = additiveDisplayHtml;
             
-            // UI情報更新 (4-1, 4-2: 改行タグを維持し、innerHTMLを使用)
+            // UI情報更新
             const summaryHtml = `${char.name_jp} ${awakeningLevel}凸 <br class="sm:hidden"> / MR${mrLevel}`;
             document.getElementById('summaryDisplay').innerHTML = summaryHtml;
 
@@ -544,7 +569,7 @@
             let resultHtml = '';
             let panelValues = [];
             
-            // 2. 特性による固定値ボーナスを計算 (修正: panel_status_at_max_level も考慮)
+            // 2. 特性による固定値ボーナスを計算
             let characteristicAdds = [];
             
             // 1. awakening_table の characteristic_additives を優先 (新しいJSON形式)
@@ -583,18 +608,14 @@
                 const totalAdditives = baseVal + awkAdd + fixedAdd + finalCharacteristicAdd; 
                 
                 const mrRate = getMRRate(mrLevel, key);
-                const baseMultiplier = 1 + mrRate + (awkMag / 100);
+                const awkMagPercent = awkMag / 100;
+                const baseMultiplier = 1 + mrRate + awkMagPercent;
                 
-                // MR補正率のサマリー表示
-                let rateString = `+${(mrRate * 100).toFixed(0)}%`;
+                // MR補正率のサマリー表示 (1. 特性固定値の表示を削除)
+                let rateString = `+${(mrRate * 100).toFixed(0)}% (${(awkMag * 100).toFixed(0)}% 覚醒)`;
                 
-                // 特性ボーナスが適用されている場合のみ追記
-                if (finalCharacteristicAdd > 0) {
-                    rateString += ` (+${finalCharacteristicAdd}特性)`;
-                }
-
                 const spanClass = (key === 'AGL') ? 'font-extrabold text-red-600' : 'font-bold text-gray-800';
-                mrSummaryHtml += `${STATUS_LABELS[key]}: <span class="${spanClass}">${rateString}</span> / `;
+                mrSummaryHtml += `${STATUS_LABELS[key]}: <span class="${spanClass}">+${(mrRate * 100).toFixed(0)}%</span> / `;
 
 
                 // 4. 基礎ステータス (Buff 0 / 編成画面) の計算
@@ -612,8 +633,11 @@
                     baseStatusForTable = Math.floor(totalAdditives * baseMultiplier);
                 }
                 
-                // 4-3. toLocaleString() を削除
-                let finalStatusCells = `<td class="result-cell text-blue-600 bg-blue-50 border-r">${baseStatusForTable}</td>`;
+                // 2. 計算式表示用データ属性 (Buff 0)
+                const dataAttributesBase = `data-stat="${key}" data-buff="0" data-totaladd="${totalAdditives}" data-basemult="${baseMultiplier}" data-baseval="${baseVal}" data-awkadd="${awkAdd}" data-fixedadd="${fixedAdd}" data-paneladd="${finalCharacteristicAdd}" data-mrrate="${mrRate}" data-awkperc="${awkMagPercent}"`;
+
+                // 4-3. カンマを削除
+                let finalStatusCells = `<td class="result-cell text-blue-600 bg-blue-50 border-r" tabindex="0" ${dataAttributesBase}>${baseStatusForTable}</td>`;
 
 
                 // 5. 戦闘中ステータス (1up, 2up, 3up) の計算
@@ -622,22 +646,32 @@
                 for (let j = 0; j < 3; j++) {
                     let cellContent;
                     const fullBuffMultiplier = buffMultipliers[j]; 
+                    const buffLevel = j + 1; // 1, 2, 3
+                    
+                    let buffRatePercentage = 0;
+                    let finalStatus = 0;
 
                     if (key === 'MP') {
                         cellContent = "-"; // MPは '-' 表示
+                        finalStatus = 0; // データ属性用に0を設定
                     } else if (key === 'HP') {
                         // HPは1up, 2up, 3upで闘技場補正後の値を使用
-                        cellContent = hpPvPValue; // 4-3. toLocaleString() を削除
+                        cellContent = hpPvPValue; 
+                        finalStatus = hpPvPValue;
+                        buffRatePercentage = BUFF_RATES_BY_STAT["HP"][0] - 1;
                     } else {
                         // ATK, DEF, AGL, WIS: Buff RateをBase Multiplierに追加し、一度だけ切り捨て
-                        const buffRatePercentage = fullBuffMultiplier - 1; 
+                        buffRatePercentage = fullBuffMultiplier - 1; 
                         const finalMultiplier = baseMultiplier + buffRatePercentage; 
                         
-                        const finalStatus = Math.floor(totalAdditives * finalMultiplier);
-                        cellContent = finalStatus; // 4-3. toLocaleString() を削除
+                        finalStatus = Math.floor(totalAdditives * finalMultiplier);
+                        cellContent = finalStatus; 
                     }
                     
-                    finalStatusCells += `<td class="result-cell text-red-600 bg-red-50 border-r">${cellContent}</td>`;
+                    // 2. 計算式表示用データ属性 (Buff 1, 2, 3)
+                    const dataAttributesBuff = `data-stat="${key}" data-buff="${buffLevel}" data-totaladd="${totalAdditives}" data-basemult="${baseMultiplier}" data-baseval="${baseVal}" data-awkadd="${awkAdd}" data-fixedadd="${fixedAdd}" data-paneladd="${finalCharacteristicAdd}" data-mrrate="${mrRate}" data-awkperc="${awkMagPercent}" data-buffperc="${buffRatePercentage}"`;
+                    
+                    finalStatusCells += `<td class="result-cell text-red-600 bg-red-50 border-r" tabindex="0" ${dataAttributesBuff}>${cellContent}</td>`;
                 }
 
                 // 6. 結果をHTMLに追加
@@ -676,6 +710,147 @@
             updateUrlParameters(selectedCharId, awakeningLevel, mrLevel, fixedValues, isPanelEnabled);
         }
         
+        // ----------------------------------------------------
+        // 5. 計算式表示機能
+        // ----------------------------------------------------
+        
+        /**
+         * 結果セルにマウスホバー/フォーカスイベントリスナーを設定する
+         * (一度だけ実行される)
+         */
+        function setupCalculationDisplayListeners() {
+            const tableBody = document.getElementById('statusResultTableBody');
+            
+            // リスナーが既に取り付けられている場合はスキップ
+            if (tableBody && tableBody.getAttribute('data-listeners-attached')) {
+                return;
+            }
+
+            // 非表示にする処理
+            const hideCalculation = () => {
+                document.getElementById('calculationDisplayContainer').classList.add('hidden');
+            };
+            
+            // 表示する処理
+            const handleCellEvent = (event) => {
+                const cell = event.target.closest('.result-cell');
+                // .result-cellの子孫でないか、データ属性がない場合は非表示
+                if (!cell || !cell.dataset.stat) {
+                    // leaveイベントなどで非表示が実行されるため、ここでは何もしない
+                    return; 
+                }
+                
+                // 計算式を生成して表示
+                const formula = generateFormula(cell.dataset);
+                document.getElementById('calculationDisplay').innerHTML = formula;
+                document.getElementById('calculationDisplayContainer').classList.remove('hidden');
+            };
+
+            // イベントデリゲーション
+            if (tableBody) {
+                // ホバー/フォーカス時
+                tableBody.addEventListener('mouseenter', handleCellEvent, true);
+                tableBody.addEventListener('focusin', handleCellEvent, true);
+                // ホバー解除/フォーカスアウト時
+                tableBody.addEventListener('mouseleave', hideCalculation, true);
+                tableBody.addEventListener('focusout', hideCalculation, true);
+                
+                // リスナー取り付け済みマーク
+                tableBody.setAttribute('data-listeners-attached', 'true');
+            }
+        }
+        
+        /**
+         * セルのデータ属性から計算式文字列を生成する
+         */
+        function generateFormula(data) {
+            const { stat, buff, totaladd, basemult, baseval, awkadd, fixedadd, paneladd, mrrate, awkperc, buffperc } = data;
+
+            const statLabel = STATUS_LABELS[stat] || stat;
+            // 数値はすべてIntまたはFloatとしてパース
+            const baseValInt = parseInt(baseval);
+            const awkAddInt = parseInt(awkadd);
+            const fixedAddInt = parseInt(fixedadd);
+            const panelAddInt = parseInt(paneladd);
+            const totalAddInt = parseInt(totaladd);
+            const mrRateFloat = parseFloat(mrrate);
+            const awkPercFloat = parseFloat(awkperc);
+            const baseMultFloat = parseFloat(basemult);
+            const buffPercFloat = parseFloat(buffperc) || 0; // MPやBaseの場合は0
+
+            // [1] Additives (加算部)
+            const additiveFormula = `(${baseValInt} [基礎] + ${awkAddInt} [覚醒] + ${fixedAddInt} [装備] + ${panelAddInt} [パネル])`;
+            const totalAddStr = totalAddInt;
+
+            // [2] Multipliers (倍率部)
+            const mrRatePercent = (mrRateFloat * 100).toFixed(0);
+            const awkMagPercent = (awkPercFloat * 100).toFixed(0);
+            const baseMultiplierFormula = `(1 + ${mrRatePercent}% [MR補正] + ${awkMagPercent}% [覚醒倍率])`;
+
+            let finalMultiplier = baseMultFloat;
+            let finalStatus;
+            let statusType = "基礎値 (Buff 0 / 編成画面)";
+            let finalFormula = `<p class="text-sm font-semibold mb-1">${statLabel} (${statusType})</p>`;
+            let calculationStep;
+            
+            // Buffed Status (1up, 2up, 3up)
+            if (buff !== "0") {
+                const buffLevel = parseInt(buff);
+                statusType = `戦闘中 (${buffLevel}up)`;
+                
+                if (stat === 'MP') {
+                    return `<p class="text-sm font-semibold mb-1">${statLabel} (${statusType})</p>MPは戦闘中変動しないため、計算式は省略します。`;
+                }
+
+                if (stat === 'HP') {
+                    // HP Buffed Columns (1up, 2up, 3up) calculation logic: 1.30x PvE multiplier
+                    const hpPvPRate = BUFF_RATES_BY_STAT["HP"][0]; // 1.30
+                    finalMultiplier = baseMultFloat * hpPvPRate;
+                    finalStatus = Math.floor(totalAddInt * finalMultiplier);
+                    
+                    const hpPvPRatePercent = ((hpPvPRate - 1) * 100).toFixed(0);
+                    
+                    finalFormula = `<p class="text-sm font-semibold mb-1">${statLabel} (${statusType})</p>`;
+                    
+                    calculationStep = `<div><span class="font-bold">中間値:</span> ${totalAddStr} x ${baseMultFloat.toFixed(4)} = ${(totalAddInt * baseMultFloat).toFixed(2)}</div>`;
+                    calculationStep += `<div class="mt-1"><span class="font-bold">計算:</span> ${additiveFormula} x ${baseMultFloat.toFixed(4)} x (1 + ${hpPvPRatePercent}% [闘技場])`;
+                    calculationStep += `<div class="mt-1">= ${totalAddStr} x ${baseMultFloat.toFixed(4)} x ${hpPvPRate.toFixed(2)} ≈ <span class="text-green-400 font-bold">${finalStatus}</span> (切り捨て)</div>`;
+
+                } else {
+                    // ATK, DEF, AGL, WIS
+                    const buffRatePercent = (buffPercFloat * 100).toFixed(0);
+                    
+                    finalMultiplier = baseMultFloat + buffPercFloat;
+                    finalStatus = Math.floor(totalAddInt * finalMultiplier);
+                    
+                    finalFormula = `<p class="text-sm font-semibold mb-1">${statLabel} (${statusType})</p>`;
+
+                    calculationStep = `<div><span class="font-bold">倍率部 (M):</span> ${baseMultiplierFormula} + ${buffRatePercent}% [Buff] = <span class="text-yellow-400 font-bold">${finalMultiplier.toFixed(4)}</span></div>`;
+                    calculationStep += `<div class="mt-2"><span class="font-bold">計算:</span> ${additiveFormula} x ${finalMultiplier.toFixed(4)}`;
+                    calculationStep += `<div class="mt-1">= ${totalAddStr} x ${finalMultiplier.toFixed(4)} ≈ <span class="text-green-400 font-bold">${finalStatus}</span> (切り捨て)</div>`;
+                }
+            } else {
+                // Base Status (Buff 0)
+                finalStatus = Math.floor(totalAddInt * baseMultFloat);
+                
+                if (stat === 'HP') {
+                    // HP Base Status calculation is without the 1.30x PvP rate.
+                }
+
+                calculationStep = `<div><span class="font-bold">倍率部 (M):</span> ${baseMultiplierFormula} = <span class="text-yellow-400 font-bold">${finalMultiplier.toFixed(4)}</span></div>`;
+                calculationStep += `<div class="mt-2"><span class="font-bold">計算:</span> ${additiveFormula} x ${finalMultiplier.toFixed(4)}`;
+                calculationStep += `<div class="mt-1">= ${totalAddStr} x ${finalMultiplier.toFixed(4)} ≈ <span class="text-green-400 font-bold">${finalStatus}</span> (切り捨て)</div>`;
+            }
+
+            finalFormula += `<div class="mt-2 space-y-1">`;
+            finalFormula += `<div><span class="font-bold">加算部 (A):</span> ${additiveFormula} = <span class="text-yellow-400 font-bold">${totalAddStr}</span></div>`;
+            finalFormula += calculationStep; // 上記で生成した計算ステップを挿入
+            finalFormula += `</div>`;
+            
+            return finalFormula;
+        }
+
+
         /**
          * 共有ボタンが押されたとき、URLを表示してコピーを試みる
          */
@@ -683,14 +858,11 @@
             const shareArea = document.getElementById('urlShareArea');
             const shareInput = document.getElementById('shareUrlInput');
             
-            // iFrame内部のURL (パラメータ付き) を取得
             const urlToCopy = window.location.href;
             shareInput.value = urlToCopy;
             
-            // 共有エリアを表示
             shareArea.classList.remove('hidden');
 
-            // 自動コピーを試みる（失敗しても手動コピーが残る）
             copyToClipboard('shareUrlInput');
         }
 
@@ -703,11 +875,9 @@
             
             if (!inputElement) return;
 
-            // 選択してコピーを試みる
             inputElement.select();
             inputElement.setSelectionRange(0, 99999); // モバイル対応
             
-            // Clipboard APIを試みる
             navigator.clipboard.writeText(inputElement.value).then(() => {
                 copyMessage.textContent = 'クリップボードにコピーしました！';
                 copyMessage.classList.remove('hidden');
@@ -715,9 +885,7 @@
                     copyMessage.classList.add('hidden');
                 }, 3000);
             }).catch(err => {
-                // 自動コピー失敗時 (Google SiteのIframeで発生しやすい)
                 console.error('自動コピー失敗', err);
-                // メッセージを更新して手動コピーを促す
                 copyMessage.textContent = '自動コピーに失敗しました。URLを選択して手動でコピーしてください。';
                 copyMessage.classList.remove('hidden');
                 setTimeout(() => {

--- a/status.html
+++ b/status.html
@@ -92,13 +92,16 @@
                 </select>
             </div>
             
-            <div>
-                <label for="awakeningLevel" class="block text-base font-semibold text-gray-700 mb-2">
+            <div class="col-span-full md:col-span-1"> <label for="awakeningLevel" class="block text-base font-semibold text-gray-700 mb-2">
                     覚醒段階 (凸数):
                 </label>
                 <select id="awakeningLevel" onchange="updateAllCalculations()" 
                         class="w-full p-3 border border-indigo-300 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-lg" disabled>
                     </select>
+            </div>
+            
+            <div id="awakeningAdditivesDisplay" class="col-span-full text-sm text-gray-600 p-2 bg-indigo-100 rounded-md">
+                現在の覚醒段階による固定値増加: --
             </div>
         </div>
 
@@ -123,9 +126,7 @@
         <div class="input-group bg-green-50">
             <h3 class="text-base font-semibold text-gray-700 mb-3 border-b border-green-200 pb-2">装備・開花による固定値増加 (合計)</h3>
             
-            <div class="mb-4 p-3 bg-gray-50 border border-gray-200 rounded-lg">
-                <label class="block text-base font-semibold text-gray-700 mb-2">
-                    才能開花/スキルパネル:
+            <div class="mb-4 p-2 bg-gray-50 border border-gray-200 rounded-lg"> <label class="block text-sm font-semibold text-gray-700 mb-2"> 才能開花/スキルパネル:
                 </label>
                 <div class="flex space-x-4">
                     <label class="inline-flex items-center">
@@ -137,41 +138,39 @@
                         <span class="ml-2 text-sm font-medium">OFF</span>
                     </label>
                 </div>
-                <div id="panelAdditiveSummary" class="mt-3 text-xs text-gray-600 p-2 bg-gray-100 rounded-md">
+                <div id="panelAdditiveSummary" class="mt-1 text-xs text-gray-600 pt-1 rounded-md"> 
                     現在選択中のキャラクターには、特性による固定値増加はありません。
                 </div>
             </div>
 
-            <div class="mb-4 flex flex-wrap gap-2 justify-center">
-                <button onclick="setFixedAgl(FASTEST_AGL_VALUE, true)" class="flex-1 min-w-[150px] bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg transition duration-150 shadow-md">
-                    ⚡ 最速装備 (すばやさ+182) 適用
+            <div class="mb-4 flex gap-3 justify-center"> <button onclick="setFixedAgl(FASTEST_AGL_VALUE, true)" class="flex-1 bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-1 text-sm rounded-lg transition duration-150 shadow-md whitespace-nowrap">
+                    ⚡ 最速装備 (+182)
                 </button>
-                <button onclick="resetFixedValues()" class="flex-1 min-w-[150px] bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded-lg transition duration-150 shadow-md">
-                    🔄 装備値リセット (全て0)
+                <button onclick="resetFixedValues()" class="flex-1 bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-1 text-sm rounded-lg transition duration-150 shadow-md whitespace-nowrap">
+                    🔄 装備値リセット
                 </button>
-                <p class="mt-1 text-xs text-gray-600 text-center w-full">
-                    ※最速装備: 獣王爪+102、ベスト+43、星腕輪+37 (34+all3)
-                </p>
             </div>
+            <p class="mt-1 text-xs text-gray-600 text-center w-full">
+                ※最速装備: 獣王爪+102、ベスト+43、星腕輪+37 (34+all3)
+            </p>
 
-            <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-                <div id="fixedInputContainer" class="col-span-full grid grid-cols-2 sm:grid-cols-3 gap-4">
+            <div class="grid grid-cols-3 gap-3">
+                <div id="fixedInputContainer" class="col-span-full grid grid-cols-3 gap-3">
                     </div>
             </div>
             <p class="mt-2 text-xs text-gray-500">※これらの固定値はMR補正・覚醒倍率の乗算対象となります。</p>
         </div>
 
         <div class="w-full bg-white py-4 rounded-lg shadow-2xl border-4 border-red-500/50">
-            <h3 class="text-xl font-bold mb-4 text-gray-800 border-b pb-2 flex justify-between items-center px-4">
-                <span>最終ステータス結果 (Lv Max)</span>
-                <span id="summaryDisplay" class="text-sm font-semibold text-gray-600">--</span>
+            <h3 class="text-lg font-bold mb-4 text-gray-800 border-b pb-2 flex justify-between items-center px-4"> <span>最終ステータス結果 (Lv Max)</span>
+                <span id="summaryDisplay" class="text-xs font-semibold text-gray-600">--</span> 
             </h3>
             
             <div class="overflow-x-auto">
                 <table class="min-w-full bg-white border border-gray-200">
                     <thead>
                         <tr class="bg-gray-100">
-                            <th class="py-2 px-1 border-b text-xs font-semibold text-gray-600">ステ (<span class="text-xs">バフ率</span>)</th>
+                            <th class="py-2 px-1 border-b text-xs font-semibold text-gray-600">ステ (<span class="text-[0.65rem]">バフ率</span>)</th>
                             <th class="py-2 px-1 border-b text-xs font-semibold text-blue-600">基礎</th>
                             <th class="py-2 px-1 border-b text-xs font-semibold text-red-600">1up</th>
                             <th class="py-2 px-1 border-b text-xs font-semibold text-red-600">2up</th>
@@ -214,7 +213,7 @@
             なおこのHTMLコードはGoogleのGeminiによって生成されました。
         </p>
         <div class="version-info mt-3">
-            <p class="text-xs text-gray-500">最終更新日: 2025/12/08 バージョン: 0.1.7 (モバイルUI改善、パネルON/OFF)</p>
+            <p class="text-xs text-gray-500">最終更新日: 2025/12/08 バージョン: 0.1.8 (パネル値修正、UI最適化)</p>
         </div>
     </div>
 
@@ -522,7 +521,21 @@
             const awakeningData = char.awakening_table.find(item => item.level === awakeningLevel);
             if (!awakeningData) return;
 
-            // UI情報更新 (1-2: 改行タグを追加し、textContentをinnerHTMLに変更)
+            // 1. 覚醒加算値の表示
+            const awkAdditives = awakeningData.additives;
+            let additiveDisplayHtml = '現在の覚醒段階による固定値増加: ';
+            const additiveParts = STATUS_KEYS.map((key, i) => {
+                return awkAdditives[i] > 0 ? `${STATUS_LABELS[key]}+${awkAdditives[i]}` : '';
+            }).filter(s => s !== '');
+
+            if (additiveParts.length > 0) {
+                additiveDisplayHtml += additiveParts.join(' / ');
+            } else {
+                additiveDisplayHtml += 'なし';
+            }
+            document.getElementById('awakeningAdditivesDisplay').innerHTML = additiveDisplayHtml;
+            
+            // UI情報更新 (4-1, 4-2: 改行タグを維持し、innerHTMLを使用)
             const summaryHtml = `${char.name_jp} ${awakeningLevel}凸 <br class="sm:hidden"> / MR${mrLevel}`;
             document.getElementById('summaryDisplay').innerHTML = summaryHtml;
 
@@ -531,6 +544,21 @@
             let resultHtml = '';
             let panelValues = [];
             
+            // 2. 特性による固定値ボーナスを計算 (修正: panel_status_at_max_level も考慮)
+            let characteristicAdds = [];
+            
+            // 1. awakening_table の characteristic_additives を優先 (新しいJSON形式)
+            if (awakeningData.characteristic_additives && awakeningData.characteristic_additives.length === 6) {
+                characteristicAdds = awakeningData.characteristic_additives;
+            } 
+            // 2. キャラクター直下の panel_status_at_max_level を使用 (古いJSON形式)
+            else if (char.panel_status_at_max_level && char.panel_status_at_max_level.length === 6) {
+                characteristicAdds = char.panel_status_at_max_level;
+            } else {
+                characteristicAdds = [0, 0, 0, 0, 0, 0];
+            }
+
+
             STATUS_KEYS.forEach((key, i) => {
                 // 1. 基本値の取得、覚醒固定値、装備固定値、特性ボーナスの計算
                 const baseVal = char.base_status_at_max_level[i];
@@ -540,16 +568,12 @@
                 const fixedAdd = parseInt(fixedInputElement.value) || 0;
                 fixedValues[key] = fixedAdd; 
                 
-                // ★★★ 2. 特性による固定値ボーナスを JSON の awakening_table から読み込む ★★★
-                let characteristicAdd = 0;
-                if (awakeningData.characteristic_additives && typeof awakeningData.characteristic_additives[i] === 'number') {
-                    characteristicAdd = awakeningData.characteristic_additives[i];
-                }
+                const characteristicAdd = characteristicAdds[i];
 
                 // パネルがONの場合のみ特性固定値を適用
                 const finalCharacteristicAdd = isPanelEnabled ? characteristicAdd : 0;
                 
-                if (characteristicAdd > 0) {
+                if (characteristicAdd > 0) { // 常にオリジナルデータに基づいて内訳を表示
                     panelValues.push({key: key, value: characteristicAdd});
                 }
 
@@ -588,7 +612,8 @@
                     baseStatusForTable = Math.floor(totalAdditives * baseMultiplier);
                 }
                 
-                let finalStatusCells = `<td class="result-cell text-blue-600 bg-blue-50 border-r">${baseStatusForTable.toLocaleString()}</td>`;
+                // 4-3. toLocaleString() を削除
+                let finalStatusCells = `<td class="result-cell text-blue-600 bg-blue-50 border-r">${baseStatusForTable}</td>`;
 
 
                 // 5. 戦闘中ステータス (1up, 2up, 3up) の計算
@@ -602,14 +627,14 @@
                         cellContent = "-"; // MPは '-' 表示
                     } else if (key === 'HP') {
                         // HPは1up, 2up, 3upで闘技場補正後の値を使用
-                        cellContent = hpPvPValue.toLocaleString();
+                        cellContent = hpPvPValue; // 4-3. toLocaleString() を削除
                     } else {
                         // ATK, DEF, AGL, WIS: Buff RateをBase Multiplierに追加し、一度だけ切り捨て
                         const buffRatePercentage = fullBuffMultiplier - 1; 
                         const finalMultiplier = baseMultiplier + buffRatePercentage; 
                         
                         const finalStatus = Math.floor(totalAdditives * finalMultiplier);
-                        cellContent = finalStatus.toLocaleString();
+                        cellContent = finalStatus; // 4-3. toLocaleString() を削除
                     }
                     
                     finalStatusCells += `<td class="result-cell text-red-600 bg-red-50 border-r">${cellContent}</td>`;

--- a/status.json
+++ b/status.json
@@ -123,8 +123,8 @@
     "id": 802,
     "name_jp": "大勇者アバン",
     "family_jp": "英雄",
-    "base_status_at_max_level": [1553, 562, 615, 564, 496, 308],
-    "panel_status_at_max_level": [0, 0, 0, 0, 0, 0],
+    "base_status_at_max_level": [1193, 400, 442, 377, 352, 222],
+    "panel_status_at_max_level": [50, 50, 25, 75, 25, 25],
     "awakening_table": [
       { "level": 0, "additives": [0, 0, 15, 0, 20, 0], "magnifiers": [0, 0, 0, 0, 0, 0] },
       { "level": 1, "additives": [0, 0, 15, 0, 20, 0], "magnifiers": [5, 5, 5, 5, 5, 5] },
@@ -138,7 +138,7 @@
     "id": 804,
     "name_jp": "真・大魔王バーン",
     "family_jp": "？？？",
-    "base_status_at_max_level": [1512, 651, 622, 536, 527, 506],
+    "base_status_at_max_level": [1180, 506, 498, 429, 422, 405],
     "panel_status_at_max_level": [0, 0, 0, 0, 0, 0],
     "awakening_table": [
       { "level": 0, "additives": [30, 15, 0, 0, 0, 0], "magnifiers": [0, 0, 0, 0, 0, 0] },


### PR DESCRIPTION
<html><head></head><body><p>ご提示いただいた「真・バーン」の図鑑ステータスを、固定値増加分ゼロの条件に基づき、真の基礎値（$P_{Base}$）に変換します。</p>
<p>この変換は、図鑑ステータスには完凸（5凸）による**25%の覚醒補正（1.25倍）**が既に含まれているという計算モデルに基づき、この補正を割り戻すことによって行われます,。</p>
<h3>基礎値の計算式（固定値増加分 0 の場合）</h3>
<p>$$
\text{基礎値}(P_{Base}) = \text{ROUNDUP} \left( \frac{\text{図鑑ステータス}}{1.25} \right)
$$</p>
<h3>計算結果</h3>

図鑑ステータス | A / 1.25 の計算 | 基礎値 $P_{Base}$ (切り上げ)
-- | -- | --
1512 | $1512 \div 1.25 = 1209.6$ | 1210
651 | $651 \div 1.25 = 520.8$ | 521
622 | $622 \div 1.25 = 497.6$ | 498
536 | $536 \div 1.25 = 428.8$ | 429
527 | $527 \div 1.25 = 421.6$ | 422
506 | $506 \div 1.25 = 404.8$ | 405


<h3>変換後の基礎値</h3>
<pre><code>{"base_status_at_max_level": }
</code></pre></body></html>

<html><head></head><body><p>ご提示いただいた「アバン」の図鑑ステータスと固定値増加分に基づき、完凸（5凸）による25%増加を割り戻し、固定値を差し引くことで、真の基礎値（$P_{Base}$）を推定する計算を行います,。</p>
<p>使用する逆算式は以下の通りです。
$$
\text{基礎値}(P_{Base}) \approx \text{ROUNDUP} \left( \left( \frac{\text{図鑑ステータス}}{1.25} \right) - \text{固定値増加分} \right)
$$</p>
<h3>各パラメータの基礎値への変換</h3>

No. | 図鑑ステータス (A) | 固定値増加分 (C) | (A / 1.25) の計算 | 逆算結果 (ROUNDUP(A/1.25 - C))
-- | -- | -- | -- | --
1 | 1553 | 50 | $1553 \div 1.25 = 1242.4$ | $\text{ROUNDUP}(1242.4 - 50) = \mathbf{1193}$
2 | 562 | 50 | $562 \div 1.25 = 449.6$ | $\text{ROUNDUP}(449.6 - 50) = \mathbf{400}$
3 | 615 | 25 | $615 \div 1.25 = 492.0$ | $\text{ROUNDUP}(492.0 - 25) = \mathbf{467}$
4 | 564 | 75 | $564 \div 1.25 = 451.2$ | $\text{ROUNDUP}(451.2 - 75) = \mathbf{377}$
5 | 496 | 25 | $496 \div 1.25 = 396.8$ | $\text{ROUNDUP}(396.8 - 25) = \mathbf{372}$
6 | 308 | 25 | $308 \div 1.25 = 246.4$ | $\text{ROUNDUP}(246.4 - 25) = \mathbf{222}$


<h3>変換後の基礎値</h3>
<pre><code>{
    "base_status_at_max_level":
}
</code></pre></body></html>